### PR TITLE
Use '+' instead of '*' in RegExp of parseUrl

### DIFF
--- a/lib/parseUrl/index.js
+++ b/lib/parseUrl/index.js
@@ -6,8 +6,8 @@
 
 var parseUrl = function(url) {
   var tmp = {},
-    match = url.match(/\?[^#]*/);
-  if (!match || match[0].length === 1) {
+    match = url.match(/\?[^#]+/);
+  if (!match) {
     return tmp;
   }
   var paramArr = match[0].slice(1).split('&');


### PR DESCRIPTION
`match` 与 `window.location.search` 一致